### PR TITLE
Increase maxBuffer to 1MB to fix verifcation issues for python3/cmake

### DIFF
--- a/lib/parsers/execute.js
+++ b/lib/parsers/execute.js
@@ -52,7 +52,7 @@ export default function execute(commands, variables) {
         logger.debug(`Executing: ${command}`);
         ChildProcess.exec(
             command,
-            { env: { ...remote.process.env, ...variables, ...macPath } },
+            { maxBuffer: 1024 * 1024, env: { ...remote.process.env, ...variables, ...macPath } },
             (error, stdout, stderr) => {
                 if (error) {
                     logger.debug(stderr.trim());


### PR DESCRIPTION
On NodeJS <= 10, the maxBuffer size is defaulted to 1024*200.  The cerification output of cmake and python3 exceed this size.  This PR updates maxBuffer to 1024*1024 (the default in NodeJS 12) so that the verifications no longer fail.