### PR TITLE
Update devdep

### DIFF
--- a/lib/components/CheckableView.jsx
+++ b/lib/components/CheckableView.jsx
@@ -107,8 +107,11 @@ const CheckableView = ({
 CheckableView.propTypes = {
     tool: PropTypes.string.isRequired,
     data: PropTypes.shape({
-        steps: PropTypes.array.isRequired,
+        automation: PropTypes.any,
+        id: PropTypes.number.isRequired,
+        isManual: PropTypes.bool.isRequired,
         runCheckers: PropTypes.func.isRequired,
+        steps: PropTypes.array.isRequired,
     }).isRequired,
     manualCheck: PropTypes.func.isRequired,
     currentState: PropTypes.string.isRequired,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
   },
   "devDependencies": {
-    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.0.0",
+    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.1.0",
     "react-markdown": "^3.6.0",
     "linux-os-info": "^2.0.0"
   },


### PR DESCRIPTION
Motivated by the updated node-sass, this also required a little cleanup
to CheckableView because the updated ESLint led to a warning about
missing properties.