### PR TITLE
Changelog as release notes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,7 @@
+## Version 1.0.3
+### Features
+- Clarify scope of #11
+- Link to user guide for nRF9160 and nRF5340 #13
+### Bugfixes
+- Reference new [docs project](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/) (replacing the [defunct wiki](https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki)) #7
+- Fix verification issues for `python3` and `cmake` #9 (Thanks, @ndrake)"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
   },
   "devDependencies": {
-    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.1.0",
-    "react-markdown": "^3.6.0",
-    "linux-os-info": "^2.0.0"
+    "linux-os-info": "^2.0.0",
+    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.3.0",
+    "react-markdown": "^3.6.0"
   },
   "dependencies": {
     "electron-store": "^2.0.0"


### PR DESCRIPTION
This is part of [NCP-2820](https://projecttools.nordicsemi.no/jira/browse/NCP-2820). The whole concept is described there.

This changes two things:
- It adds a `Changelog.md` which contains all entries that were previously in the GitHub releases.
- It references devdep 3.3 so that future releases of this app will also upload the `Changelog.md` to developer.nordicsemi.com.

Because this changes depends on the release of devdep 3.3, this PR is created as a draft PR and  will be marked as being ready later when NordicSemiconductor/pc-nrfconnect-devdep#26 is merged and devdep 3.3 is released.