### PR TITLE
fix error: fatal error: git2.h file not found on darwin

### DIFF
--- a/resources/data/nrf_connect_sdk-0.1.3.json
+++ b/resources/data/nrf_connect_sdk-0.1.3.json
@@ -163,6 +163,7 @@
                             "type": "commands",
                             "description": [
                                 "cd <sourcecode_root>/ncs",
+                                "brew install libgit2",
                                 "pip3 install --user -r zephyr/scripts/requirements.txt",
                                 "pip3 install --user -r nrf/scripts/requirements.txt",
                                 "pip3 install --user -r mcuboot/scripts/requirements.txt"


### PR DESCRIPTION
The easiest way is to first install libgit2 with the Homebrew package manager and then use pip3 for pygit2. The following example assumes that XCode and Hombrew are already installed.

`brew update
brew install libgit2
pip3 install pygit2`