### PR TITLE
Update text regarding SDK device family support

### DIFF
--- a/resources/data/course-zephyr.json
+++ b/resources/data/course-zephyr.json
@@ -8,7 +8,7 @@
     ],
     "description": [
         "The nRF Connect SDK contains libraries and application examples for Nordic Semiconductor devices. It uses the Zephyr Project as real-time operating system.",
-        "The nRF Connect SDK supports nRF53 and nRF91 Series devices. For nRF51 and nRF52 Series devices, we recommend using the [nRF5 SDK](https://www.nordicsemi.com/Software-and-tools/Software/nRF5-SDK) instead. See our [Software development Getting Started Guides](https://infocenter.nordicsemi.com/topic/struct_nrf5gs/struct/nrf5gs_sw_dev.html) for more information.",
+        "The nRF Connect SDK supports nRF52, nRF53 and nRF91 Series devices. See our [Software development Getting Started Guides](https://infocenter.nordicsemi.com/topic/struct_nrf5gs/struct/nrf5gs_sw_dev.html) for more information.",
 
         "#### Getting started",
         "This app helps you to set up your nRF Connect SDK development environment. It guides you through installing the required software:",


### PR DESCRIPTION
nRF Connect SDK now has support for nRF52. nRF51 users will still find information by following the link to "more information".