### PR TITLE
Prepare for release v2.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## 2.1.0 - 2022-06-03
+
+### Removed
+
+-   Support for Ubuntu. Toolchain Manager should be used by all supported
+    platforms.
+
 ## 2.0.2 - 2022-02-28
 
 -   Made compatible with next version of nRF Connect for Desktop.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-gettingstarted",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "displayName": "Getting Started Assistant",
     "description": "Guide for setting up toolchains and getting the code for nRF Connect SDK",
     "repository": {


### PR DESCRIPTION
v2.1.0 is a deprecated version of the getting started application.